### PR TITLE
Determine storage folder correctly

### DIFF
--- a/Classes/Command/CompressImagesCommandController.php
+++ b/Classes/Command/CompressImagesCommandController.php
@@ -70,7 +70,7 @@ class CompressImagesCommandController extends CommandController
         foreach ($files as $file) {
             if ($file instanceof \Schmitzal\Tinyimg\Domain\Model\File) {
                 $file = $this->resourceFactory->getFileObject($file->getUid());
-                $folder = $this->resourceFactory->getFolderObjectFromCombinedIdentifier($file->getParentFolder());
+                $folder = $this->resourceFactory->getFolderObjectFromCombinedIdentifier($file->getParentFolder()->getIdentifier());
                 if (filesize(GeneralUtility::getFileAbsFileName($file->getPublicUrl())) > 0) {
                     $this->compressImageService->initializeCompression($file, $folder);
                 }


### PR DESCRIPTION
Hi,

with debugging enabled within the TYPO3 backend I got this PHP Warning instead of a running Command Task:	
_Execution of task "Extbase CommandController Task (extbase)" failed with the following message: PHP Warning: explode() expects parameter 2 to be string, object given in C:\Users\ank\Downloads\typo3_src-8.7.15\typo3\sysext\core\Classes\Utility\GeneralUtility.php line 1302_

I found the responsible code part and tried to fix it. In my opinion it now should work as intented, but you should also look over it and test it with multiple storages.
Reason was the method "getFolderObjectFromCombinedIdentifier" became a folder object but wanted a string like '1:user_upload/'. The fallback is to use the default storage which in most cases I guess was sufficient.