### PR TITLE
[CLEANUP] Remove package "security-advisories" from composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,6 @@
         "typo3/cms": ">=7.6.0",
         "tinify/tinify": "^1.5"
     },
-    "require-dev": {
-        "roave/security-advisories": "dev-master"
-    },
     "autoload": {
         "psr-4": {
             "Schmitzal\\Tinyimg\\": "Classes"


### PR DESCRIPTION
as it breaks when requiring tinyimg on a TYPO3 7.6 setup