### PR TITLE
Check for file in local file system if no S3 Configured

### DIFF
--- a/Classes/Service/CompressImageService.php
+++ b/Classes/Service/CompressImageService.php
@@ -150,7 +150,9 @@ class CompressImageService
 
         if ((int)($this->settings['debug'] ?? 1) === 0) {
             try {
-                $this->assureFileExists($file);
+                if(!$this->getUseCdn()){
+                    $this->assureFileExists($file);
+                }
                 $originalFileSize = $file->getSize();
                 if ($this->checkForAmazonCdn($file)) {
                     $fileSize = $this->pushToTinyPngAndStoreToCdn($file);


### PR DESCRIPTION
Fixed issue if S3 is connected with compression the function returns wrong image paths for compression causing errors of file does not exist.