### PR TITLE
[FIX] Fix nullable name parameter in CompressImagesCommand to avoid PHP deprecation warnings

### DIFF
--- a/Classes/Command/CompressImagesCommand.php
+++ b/Classes/Command/CompressImagesCommand.php
@@ -41,7 +41,7 @@ final class CompressImagesCommand extends Command
         private readonly FileRepository $fileRepository,
         private readonly ResourceFactory $resourceFactory,
         private readonly CompressImageService $compressImageService,
-        string $name = null
+        ?string $name = null
     ) {
         parent::__construct($name);
     }


### PR DESCRIPTION
With PHP 8.4 we're getting the following deprecation warning:

```bash
PHP Deprecated:  Schmitzal\Tinyimg\Command\CompressImagesCommand::__construct(): Implicitly marking parameter $name as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/schmitzal/tinyimg/Classes/Command/CompressImagesCommand.php on line 39
```

This PR fixes this issue. 